### PR TITLE
feat: Adding robotnik_docker_supervisor_interfaces

### DIFF
--- a/robotnik_docker_supervisor_interfaces/CMakeLists.txt
+++ b/robotnik_docker_supervisor_interfaces/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.8)
+project(robotnik_docker_supervisor_interfaces)
+
+# Find necessary packages
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+
+# List service files
+set(srv_files
+  "srv/GetComposeList.srv"
+  "srv/ComposeCommand.srv"
+  "srv/ComposeCommandAll.srv"
+  "srv/ComposeStatus.srv"
+  "srv/ComposeLogs.srv"
+  "srv/GetContainerList.srv"        
+  "srv/ContainerCommand.srv"
+)
+
+# Generate the ROS2 interfaces
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${srv_files}
+  DEPENDENCIES builtin_interfaces
+)
+
+# Export runtime dependencies
+ament_export_dependencies(rosidl_default_runtime)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/robotnik_docker_supervisor_interfaces/package.xml
+++ b/robotnik_docker_supervisor_interfaces/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>robotnik_docker_supervisor_interfaces</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="robot@todo.todo">robot</maintainer>
+  <license>TODO: License declaration</license>
+
+  <!-- This tag is required for interface packages -->
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/robotnik_docker_supervisor_interfaces/srv/ComposeCommand.srv
+++ b/robotnik_docker_supervisor_interfaces/srv/ComposeCommand.srv
@@ -1,0 +1,5 @@
+string stack_name
+string command  # Valid values: "up", "down", "stop", "restart" 
+---
+bool success
+string message

--- a/robotnik_docker_supervisor_interfaces/srv/ComposeCommandAll.srv
+++ b/robotnik_docker_supervisor_interfaces/srv/ComposeCommandAll.srv
@@ -1,0 +1,4 @@
+string command  # Valid values: "up", "down", "stop", "restart"
+---
+bool success
+string message

--- a/robotnik_docker_supervisor_interfaces/srv/ComposeLogs.srv
+++ b/robotnik_docker_supervisor_interfaces/srv/ComposeLogs.srv
@@ -1,0 +1,3 @@
+string stack_name
+---
+string logs

--- a/robotnik_docker_supervisor_interfaces/srv/ComposeStatus.srv
+++ b/robotnik_docker_supervisor_interfaces/srv/ComposeStatus.srv
@@ -1,0 +1,3 @@
+string stack_name
+---
+string status   # "running", "stopped", or "partial"

--- a/robotnik_docker_supervisor_interfaces/srv/ContainerCommand.srv
+++ b/robotnik_docker_supervisor_interfaces/srv/ContainerCommand.srv
@@ -1,0 +1,6 @@
+string stack_name
+string container_name
+string command   # Valores válidos: "start" o "stop"
+---
+bool success
+string message

--- a/robotnik_docker_supervisor_interfaces/srv/GetComposeList.srv
+++ b/robotnik_docker_supervisor_interfaces/srv/GetComposeList.srv
@@ -1,0 +1,3 @@
+# Request is empty
+---
+string[] compose_list

--- a/robotnik_docker_supervisor_interfaces/srv/GetContainerList.srv
+++ b/robotnik_docker_supervisor_interfaces/srv/GetContainerList.srv
@@ -1,0 +1,3 @@
+string stack_name
+---
+string[] container_list


### PR DESCRIPTION
Adding the robotnik_docker_supervisor_interfaces in order to run the services of the robotnik_docker_supervisor package. This will be used to run the services of ROS2 that manage and monitor the stacks and individual containers of the deploy.
![docker_supervisor](https://github.com/user-attachments/assets/96f180df-1ee4-4ed9-843d-73fd6cb64c19)

