### PR TITLE
feat: Add opta docking mode

### DIFF
--- a/robotnik_battery_msgs/msg/DockingStationStatus.msg
+++ b/robotnik_battery_msgs/msg/DockingStationStatus.msg
@@ -7,6 +7,8 @@ string MODE_AUTO_HW=automatic_hw
 string MODE_AUTO_SW=automatic_sw
 # Unattended relay detection & and manual activation of the charging relay
 string MODE_MANUAL_SW=manual_sw
+# Unattended relay detection & activation with no inputs/outputs feedback. Done by the hw. This can be enabled/disabled by sw
+string MODE_OPTA=opta
 
 string operation_mode
 

--- a/robotnik_battery_msgs/msg/DockingStationStatus.msg
+++ b/robotnik_battery_msgs/msg/DockingStationStatus.msg
@@ -7,10 +7,9 @@ string MODE_AUTO_HW=automatic_hw
 string MODE_AUTO_SW=automatic_sw
 # Unattended relay detection & and manual activation of the charging relay
 string MODE_MANUAL_SW=manual_sw
-# Unattended relay detection & activation with no inputs/outputs feedback. Done by the hw. This can be enabled/disabled by sw
-string MODE_OPTA=opta
 
 string operation_mode
 
 bool contact_relay_status	# shows if there's contact with the charger
 bool charger_relay_status   # shows if the relay for the charge is active or not
+bool charger_enabled_status # shows if the charger is enabled or not. This is the one that should be used to know if the robot is able to charge phisically or not


### PR DESCRIPTION
This pull request makes a small update to the `DockingStationStatus` message definition by adding a new status field. This new field provides clearer information about whether the charger is physically enabled.

- Message definition update:
  * Added a new boolean field, `charger_enabled_status`, to the `DockingStationStatus.msg` file to indicate if the charger is physically enabled and the robot is able to charge.